### PR TITLE
Consistently name package tomojs_pytools.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,8 +98,8 @@ jobs:
         id: files
         run: |
           cd ${{steps.download.outputs.download-path}}
-          echo ::set-output name=file1::$(ls tomojs-pytools*any.whl)
-          echo ::set-output name=file2::$(ls tomojs-pytools*.tar.gz)
+          echo ::set-output name=file1::$(ls tomojs_pytools*any.whl)
+          echo ::set-output name=file2::$(ls tomojs_pytools*.tar.gz)
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,9 @@ Neuroglancer precompute pyramid formats.
 Installation
 ------------
 
-Use `pip` to install the pytools package:
+Use `pip` to install the tomojs_pytools package:
 
-`python3 -m pip install pytools`
+`python3 -m pip install  tomojs_pytools`
 
 The requirements are specified conventionally in requirements.txt and
 setup.py, so they will be enforced at installation time. Additionally,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("requirements.txt", "r") as fp:
     requirements = list(filter(bool, (line.strip() for line in fp)))
 
 setup(
-    name="tomojs-pytools",
+    name="tomojs_pytools",
     use_scm_version={"local_scheme": "dirty-tag"},
     author="Bradley Lowekamp",
     author_email="bioinformatics@niaid.nih.gov",


### PR DESCRIPTION
Consitently use underscore in name of package since wheels convert '-'
to '_'.