### PR TITLE
Fix 'Package "pytools" is not installed message.

### DIFF
--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -12,20 +12,22 @@
 #  limitations under the License.
 #
 
+_installed_package = "tomojs_pytools"
+
 try:
     from importlib.metadata import version, PackageNotFoundError
 
-    __version__ = version(__name__)
+    __version__ = version(_installed_package)
 except ImportError:
     from pkg_resources import get_distribution, DistributionNotFound
 
     try:
-        __version__ = get_distribution(__name__).version
+        __version__ = get_distribution(_installed_package).version
     except DistributionNotFound:
         import logging
 
         _logger = logging.getLogger(__name__)
-        _logger.warning(f'Package "{__package__}" is not installed. Unable to determine version!')
+        _logger.warning(f'Package "{_installed_package }" is not installed. Unable to determine version!')
         __version__ = "dev"
         # package is not installed
         pass

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ setuptools_scm
 flake8
 black
 wheel
+packaging
 -rrequirements.txt

--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -1,0 +1,23 @@
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import pytools
+
+
+def test_pytools_version():
+    assert pytools.__version__ != "unknown"
+
+    from packaging.version import parse, Version
+
+    assert isinstance(parse(pytools.__version__), Version)


### PR DESCRIPTION
The name of the installed package is different than the name of the
package which is imported. The introspection is correct to the name of
the installed package.