### PR TITLE
Relax verison of to numpy>=1.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-SimpleITK ==2.0.2
+SimpleITK ~=2.1.1
 neuroglancer-scripts ==0.3.0
 click >=7.1
-numpy >=1.19, <=1.20
+numpy >=1.21

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,12 @@ setup(
         ]
     },
     classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
+        # The version is <1.0, and there may be API incompatibilities from minor version to minor version
+        "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=requirements,
 )


### PR DESCRIPTION
This addresses CVE-2021-33430.

Update SimpleITK to 2.1.1