### PR TITLE
Support float pixels for histogram computation

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,7 +43,15 @@ def image_mrc(request, tmp_path_factory):
         pixel_type = request.param
         print(f"Calling image_mrc with {sitk.GetPixelIDValueAsString(pixel_type)}")
         fn = f"image_mrc_{sitk.GetPixelIDValueAsString(pixel_type).replace(' ', '_')}.mrc"
-        img = sitk.Image([10, 9, 8], pixel_type)
+
+        size = [10, 9, 8]
+        if pixel_type == sitk.sitkFloat32:
+
+            a = np.linspace(0.0, 1.0, num=np.prod(size), dtype=np.float32).reshape(*size[::-1])
+            img = sitk.GetImageFromArray(a)
+        else:
+            # image of just zeros
+            img = sitk.Image([10, 9, 8], pixel_type)
         img.SetSpacing([1.1, 1.2, 1.3])
 
     fn = tmp_path_factory.mktemp("data").joinpath(fn)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,7 +18,15 @@ import numpy as np
 
 @pytest.fixture(
     scope="session",
-    params=[sitk.sitkUInt8, sitk.sitkInt16, sitk.sitkUInt16, sitk.sitkFloat32, "uint16_uniform", "uint8_bimodal"],
+    params=[
+        sitk.sitkUInt8,
+        sitk.sitkInt16,
+        sitk.sitkUInt16,
+        sitk.sitkFloat32,
+        "uint16_uniform",
+        "uint8_bimodal",
+        "float32_uniform",
+    ],
 )
 def image_mrc(request, tmp_path_factory):
     if isinstance(request.param, str) and request.param == "uint16_uniform":
@@ -39,6 +47,15 @@ def image_mrc(request, tmp_path_factory):
         a[len(a) // 2 :] = 255
         img = sitk.GetImageFromArray(a)
         img.SetSpacing([12.3, 12.3, 56.7])
+    elif isinstance(request.param, str) and request.param == "float32_uniform":
+
+        print(f"Calling image_mrc with {request.param}")
+        fn = f"image_mrc_{request.param.replace(' ', '_')}.mrc"
+
+        a = np.linspace(0.0, 1.0, num=16 * 64 * 64, dtype=np.float32).reshape(16, 64, 64)
+        print(a)
+        img = sitk.GetImageFromArray(a)
+        img.SetSpacing([1.23, 1.23, 4.96])
     else:
         pixel_type = request.param
         print(f"Calling image_mrc with {sitk.GetPixelIDValueAsString(pixel_type)}")

--- a/test/test_histogram.py
+++ b/test/test_histogram.py
@@ -132,10 +132,11 @@ def test_histogram_mai_help(cli_args):
         ("uint16_uniform", 8191, 57344, 0, 65535, False),
         ("uint8_bimodal", 0, 255, 0, 255, True),
         ("uint8_bimodal", -64, 319, 0, 255, False),
+        (sitk.sitkFloat32, 0, 1, 0, 1, True),
     ],
     indirect=["image_mrc"],
 )
-def test_build_histogram_main(image_mrc, expected_min, expected_max, expected_floor, clamp, expected_limit):
+def test_build_histogram_main(image_mrc, expected_min, expected_max, expected_floor, expected_limit, clamp):
     runner = CliRunner()
     output_filename = "out.json"
     args = [image_mrc, "--mad", "1.5", "--output-json", output_filename]

--- a/test/test_histogram.py
+++ b/test/test_histogram.py
@@ -78,11 +78,7 @@ def test_histogram_robust_stats():
 
 @pytest.mark.parametrize(
     "image_mrc",
-    [
-        sitk.sitkUInt8,
-        sitk.sitkInt16,
-        sitk.sitkUInt16,
-    ],
+    [sitk.sitkUInt8, sitk.sitkInt16, sitk.sitkUInt16, sitk.sitkFloat32],
     indirect=["image_mrc"],
 )
 def test_stream_build_histogram(image_mrc):
@@ -107,9 +103,8 @@ def test_stream_build_histogram(image_mrc):
     ]
     for args in test_args:
         h, b = pytools_hist.stream_build_histogram(image_mrc, **args)
-
         assert np.sum(h) == img.GetNumberOfPixels(), f"with args '{args}'"
-        assert np.sum(h * (b[1:] + b[:-1])) == np.sum(sitk.GetArrayViewFromImage(img)), f"with args '{args}'"
+        assert np.sum(h * 0.5 * (b[1:] + b[:-1])) == np.sum(sitk.GetArrayViewFromImage(img)), f"with args '{args}'"
 
 
 args = ["--help", "--version"]
@@ -130,6 +125,7 @@ def test_histogram_mai_help(cli_args):
         (sitk.sitkUInt16, 0, 0, 0, 0, False),
         ("uint16_uniform", 8191, 57344, 0, 65535, True),
         ("uint16_uniform", 8191, 57344, 0, 65535, False),
+        ("float32_uniform", 0, 1, 0, 1, False),
         ("uint8_bimodal", 0, 255, 0, 255, True),
         ("uint8_bimodal", -64, 319, 0, 255, False),
         (sitk.sitkFloat32, 0, 1, 0, 1, True),


### PR DESCRIPTION
Add extra step which reads whole image and computes the minimum and maximum of the input image. Then constructs the histogram bins.

addresses #37