### PR TITLE
Set nibabel version for compatibility with neroglancer scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 SimpleITK ~=2.2.0
+nibabel <5.0
 neuroglancer-scripts ~=1.0.0
 click >=7.1
 numpy >=1.21


### PR DESCRIPTION
The neuroglancer scripts is using a depricated and removed method in nibabel.