### PR TITLE
Update required neuroglancer-scripts ~=1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 SimpleITK ~=2.2.0
-nibabel <5.0
-neuroglancer-scripts ~=1.0.0
+neuroglancer-scripts ~=1.1.0
 click >=7.1
 numpy >=1.21


### PR DESCRIPTION
The 1.0.1 includes updates which address nibable >=5.0 compatibilities, and add arguments --compresslevel command line argument.