### PR TITLE
Compute histogram with Dask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-SimpleITK ~=2.2.0
+SimpleITK ~= 2.2.0
 click >=7.1
 numpy >=1.21
 zarr
 dask
+SimpleITKUtilities@git+https://github.com/SimpleITK/SimpleITKUtilities@main


### PR DESCRIPTION
Changes from using the single threaded reading with interactive SimpleITK reading to using concurrent reading into dask arrays yielding a significant performance improvement.