### PR TITLE
exclude fspec 2023.9.0 version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest>=6.0
+fsspec!=2023.9.0
 ome_zarr
 setuptools_scm
 flake8


### PR DESCRIPTION
Fixes errors such as:
  File ".../tomojs-pytools/venv2/lib/python3.11/site-packages/fsspec/implementations/local.py", line 303, in _open
    self.f = open(self.path, mode=self.mode)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '.../tomojs-pytools/test.zarr/0/0/0/0'