### PR TITLE
Fix typo in Flour used to detect non RGB

### DIFF
--- a/pytools/utils/OMEInfo.py
+++ b/pytools/utils/OMEInfo.py
@@ -45,7 +45,7 @@ class OMEInfo:
         three_or_four = len(channel_elements) in [3, 4]
 
         def _check_channel(channel_element: ET.Element):
-            exclude_list_attribs = ["EmissionWavelength", "IlluminationType", "Flour"]
+            exclude_list_attribs = ["EmissionWavelength", "IlluminationType", "Fluor"]
             no_rgb_exclude_attrib = all([False for x in exclude_list_attribs if x in channel_element.keys()])
             return no_rgb_exclude_attrib and channel_element.attrib["SamplesPerPixel"] == "1"
 


### PR DESCRIPTION
Provided OME TIFF files are now correctly identified as multi-channel images from the OME XML metadata.