### PR TITLE
Fix line wrapping in neruglancer gray shader

### DIFF
--- a/pytools/ng/viz.py
+++ b/pytools/ng/viz.py
@@ -31,8 +31,8 @@ void main() {
 """
 
 _gray_shader_template = """
-#uicontrol invlerp normalized(range=[{{range[0]}}, {{range[1]}}],
-    window=[{{window[0]}}, {{window[1]}}], clamp=true)
+#uicontrol invlerp normalized(range=[{{range[0]}}, {{range[1]}}], \
+window=[{{window[0]}}, {{window[1]}}], clamp=true)
 void main() {
   emitGrayscale(normalized());
 }


### PR DESCRIPTION
In the NG shared line wrapping is not supported. Error likely introduce by a linter.