### PR TITLE
Use OME XML IlluminationType to detect fluorescence as multichannel

### DIFF
--- a/pytools/HedwigZarrImage.py
+++ b/pytools/HedwigZarrImage.py
@@ -250,8 +250,11 @@ class HedwigZarrImage:
         """
         Produces the shader type one of: RGB, Grayscale, or MultiChannel.
         """
-        if self.ome_info and self.ome_info.maybe_rgb(self.ome_idx):
-            return "RGB"
+        if self.ome_info:
+            if self.ome_info.maybe_rgb(self.ome_idx):
+                return "RGB"
+            elif self.ome_info.maybe_flourescence(self.ome_idx):
+                return "MultiChannel"
         if self._ome_ngff_multiscale_dims()[1] == "C" and self.shape[1] == 1:
             return "Grayscale"
         return "MultiChannel"

--- a/pytools/utils/OMEInfo.py
+++ b/pytools/utils/OMEInfo.py
@@ -44,6 +44,23 @@ class OMEInfo:
             if "Name" in e.attrib:
                 yield e.attrib["Name"]
 
+    def maybe_flourescence(self, image_index):
+        """
+        Checks if all the channels' "IlluminationType" attribute is "Epifluorescence".
+        """
+
+        px_element = self._image_element(image_index).find("OME:Pixels", self._ome_ns)
+        channel_elements = px_element.findall("./OME:Channel", self._ome_ns)
+
+        def _check_channel(channel_element: ET.Element):
+            if channel_element.attrib["SamplesPerPixel"] != "1":
+                return False
+            if channel_element.attrib.get("IlluminationType") == "Epifluorescence":
+                return True
+            return False
+
+        return all([_check_channel(ce) for ce in channel_elements])
+
     def maybe_rgb(self, image_index):
         px_element = self._image_element(image_index).find("OME:Pixels", self._ome_ns)
         channel_elements = px_element.findall("./OME:Channel", self._ome_ns)


### PR DESCRIPTION
This add support of CZI file which are fluorescence but only have one channel to be detected as needing a multi-channel shader.