### PR TITLE
Add testing for xml meta-data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
   rev: 22.8.0
   hooks:
    - id: black
-     args: ['--check', '--diff']
 - repo: https://github.com/pycqa/flake8
   rev: 5.0.4
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ fail_fast: true
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v5.0.0
   hooks:
    -   id: check-added-large-files
        args: ['--maxkb=200']
@@ -15,7 +15,7 @@ repos:
   hooks:
    - id: black
 - repo: https://github.com/pycqa/flake8
-  rev: 5.0.4
+  rev: 7.1.2
   hooks:
    - id: flake8
      args: [--max-line-length=120,  --ignore=E203]

--- a/pytools/HedwigZarrImage.py
+++ b/pytools/HedwigZarrImage.py
@@ -296,7 +296,7 @@ class HedwigZarrImage:
         if len(list(self.ome_info.channel_names(self.ome_idx))) != self.shape[1]:
             raise RuntimeError(
                 f"Mismatch of number of Channels! Array has {self.shape[1]} but there"
-                f"are {len(list(self.ome_info.channel_names(self.ome_idx)))} names:"
+                f"are {len(list(self.ome_info.channel_names(self.ome_idx)))} names: "
                 f"{list(self.ome_info.channel_names(self.ome_idx))}"
             )
 

--- a/pytools/ng/viz.py
+++ b/pytools/ng/viz.py
@@ -158,8 +158,8 @@ def generate_ng_shader(path: Path, key: Union[int, str]) -> str:
     This will call teh HewdigZarrImages class to get the shader parameters for the image which can be computationaly
     expensive so the results a cached.
     """
-    global _shader_parameter_cache
 
+    global _shader_parameter_cache  # noqa: F824
     hwz_images = HedwigZarrImages(path)
     hwz_image = hwz_images.group(key)
 

--- a/pytools/zarr_extract_2d.py
+++ b/pytools/zarr_extract_2d.py
@@ -185,7 +185,7 @@ def zarr_extract_2d(
 
     logger.debug(img)
 
-    logger.debug(f"resizing image of: {img.GetSize() } -> {(target_size_x, target_size_y)}")
+    logger.debug(f"resizing image of: {img.GetSize()} -> {(target_size_x, target_size_y)}")
     img = sitk.utilities.resize(img, (target_size_x, target_size_y), interpolator=sitk.sitkLinear, fill=False)
 
     if output_filename is not None:

--- a/test/data/dapi_one_channel.xml
+++ b/test/data/dapi_one_channel.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a789a01e6342150bc1824bf450662c982c0a5ecd2e25a2c20d497060482ed7d6
+size 11789

--- a/test/data/he_rgb.xml
+++ b/test/data/he_rgb.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b975c1f0306779c55d22323df514107a6d795f498e8a0f24f42c069805d303b
+size 11254

--- a/test/test_histogram.py
+++ b/test/test_histogram.py
@@ -107,10 +107,10 @@ def test_build_histogram_main(image_mrc, expected_min, expected_max, expected_fl
     assert float(res["neuroglancerPrecomputedMax"]) == expected_max
     assert float(res["neuroglancerPrecomputedFloor"]) == expected_floor
     assert float(res["neuroglancerPrecomputedLimit"]) == expected_limit
-    assert type(res["neuroglancerPrecomputedMin"]) == str
-    assert type(res["neuroglancerPrecomputedMax"]) == str
-    assert type(res["neuroglancerPrecomputedFloor"]) == str
-    assert type(res["neuroglancerPrecomputedLimit"]) == str
+    assert isinstance(res["neuroglancerPrecomputedMin"], str)
+    assert isinstance(res["neuroglancerPrecomputedMax"], str)
+    assert isinstance(res["neuroglancerPrecomputedFloor"], str)
+    assert isinstance(res["neuroglancerPrecomputedLimit"], str)
 
 
 def test_build_histogram_zarr_main(image_ome_ngff):
@@ -120,7 +120,7 @@ def test_build_histogram_zarr_main(image_ome_ngff):
     assert "neuroglancerPrecomputedMax" in res
     assert "neuroglancerPrecomputedFloor" in res
     assert "neuroglancerPrecomputedLimit" in res
-    assert type(res["neuroglancerPrecomputedMin"]) == str
-    assert type(res["neuroglancerPrecomputedMax"]) == str
-    assert type(res["neuroglancerPrecomputedFloor"]) == str
-    assert type(res["neuroglancerPrecomputedLimit"]) == str
+    assert isinstance(res["neuroglancerPrecomputedMin"], str)
+    assert isinstance(res["neuroglancerPrecomputedMax"], str)
+    assert isinstance(res["neuroglancerPrecomputedFloor"], str)
+    assert isinstance(res["neuroglancerPrecomputedLimit"], str)

--- a/test/test_omeinfo.py
+++ b/test/test_omeinfo.py
@@ -61,3 +61,60 @@ def test_ome_annotations_info(data_path, xml_file):
 
         # check the second ROI in the union is of type ROIRectangle
         assert isinstance(ome_roi_model.union[1], ROIRectangle)
+
+
+@pytest.mark.parametrize("xml_file", ["dapi_one_channel.xml"])
+def test_ome_fluorescence(data_path, xml_file):
+    """
+    Tests attributes of valid zarr image OMEInfo object
+    """
+    with open(data_path / xml_file, "r") as fp:
+        ome_info = OMEInfo(fp.read())
+
+    assert ome_info.number_of_images() == 6
+
+    for idx in range(ome_info.number_of_images() - 2):
+        assert ome_info.maybe_flourescence(idx) is True
+        assert ome_info.maybe_rgb(idx) is False
+        assert tuple(ome_info.channel_names(idx)) == ("DAPI",)
+
+    # image 5 and 6 should be RGB not fluorescence
+    assert ome_info.maybe_flourescence(4) is False
+    assert ome_info.maybe_rgb(4) is True
+    assert ome_info.maybe_flourescence(5) is False
+    assert ome_info.maybe_rgb(5) is True
+
+    # Check that the last two images are named "label image" and "macro image"
+    assert tuple(ome_info.image_names()) == (
+        "ScanRegion0",
+        "ScanRegion1",
+        "ScanRegion2",
+        "ScanRegion3",
+        "label image",
+        "macro image",
+    )
+
+
+@pytest.mark.parametrize("xml_file", ["he_rgb.xml"])
+def test_ome_rgb(data_path, xml_file):
+    """
+    Tests attributes of valid zarr image OMEInfo object
+    """
+    with open(data_path / xml_file, "r") as fp:
+        ome_info = OMEInfo(fp.read())
+
+    assert ome_info.number_of_images() == 5
+
+    for idx in range(ome_info.number_of_images() - 2):
+        assert ome_info.maybe_flourescence(idx) is False
+        assert ome_info.maybe_rgb(idx) is True
+        assert tuple(ome_info.channel_names(idx)) == ("TL Brightfield", "TL Brightfield", "TL Brightfield")
+
+    # image 5 and 6 should be RGB not fluorescence
+    assert ome_info.maybe_flourescence(4) is False
+    assert ome_info.maybe_rgb(3) is True
+    assert ome_info.maybe_flourescence(4) is False
+    assert ome_info.maybe_rgb(4) is True
+
+    # Check that the last two images are named "label image" and "macro image"
+    assert tuple(ome_info.image_names()) == ("ScanRegion0", "ScanRegion1", "ScanRegion2", "label image", "macro image")

--- a/test/test_omeinfo.py
+++ b/test/test_omeinfo.py
@@ -57,7 +57,7 @@ def test_ome_annotations_info(data_path, xml_file):
 
         # check the first ROI in the union is of type ROILabel
         assert isinstance(ome_roi_model.union[0], ROILabel)
-        assert ome_roi_model.union[0].text == f"{i+1:03d}"
+        assert ome_roi_model.union[0].text == f"{i + 1:03d}"
 
         # check the second ROI in the union is of type ROIRectangle
         assert isinstance(ome_roi_model.union[1], ROIRectangle)


### PR DESCRIPTION
The new images provided were a in CZI format, and then converted to OME-ZARR. The first was an HE stained images was a 3-channel RGB imaged. And the second was an flourescence image with only one channel.