### PR TITLE
Fix ome image name

### DIFF
--- a/pytools/utils/OMEInfo.py
+++ b/pytools/utils/OMEInfo.py
@@ -36,7 +36,7 @@ class OMEInfo:
 
     def image_names(self) -> Iterable[str]:
         for counter, e in enumerate(self._root_element.iterfind("OME:Image", self._ome_ns)):
-            yield e.attrib["Name"] or f"Scene #{counter}"
+            yield e.attrib.get("Name") or f"Scene #{counter}"
 
     def channel_names(self, image_index) -> Iterable[str]:
         el = self._image_element(image_index).iterfind("OME:Pixels/OME:Channel", self._ome_ns)

--- a/test/data/xenium_morphology.xml
+++ b/test/data/xenium_morphology.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54a827079b9d12b81ac9108f1a07cb185a177d6a48c0dfc6212b8528a4f6bc6a
+size 1720

--- a/test/test_omeinfo.py
+++ b/test/test_omeinfo.py
@@ -95,6 +95,30 @@ def test_ome_fluorescence(data_path, xml_file):
     )
 
 
+@pytest.mark.parametrize("xml_file", ["xenium_morphology.xml"])
+def test_ome_xenium_morphology(data_path, xml_file):
+    """
+    Tests OMEInfo with a Xenium morphology XML where the Image element has no Name attribute.
+    """
+    with open(data_path / xml_file, "r") as fp:
+        ome_info = OMEInfo(fp.read())
+
+    assert ome_info.number_of_images() == 1
+
+    # Image has no Name attribute — should fall back to the generated scene name
+    assert tuple(ome_info.image_names()) == ("Scene #0",)
+
+    # Single DAPI channel
+    assert tuple(ome_info.channel_names(0)) == ("DAPI",)
+
+    # One channel only, so not RGB; no IlluminationType, so not fluorescence
+    assert ome_info.maybe_rgb(0) is False
+    assert ome_info.maybe_flourescence(0) is False
+
+    # No ROIs
+    assert list(ome_info.roi(0)) == []
+
+
 @pytest.mark.parametrize("xml_file", ["he_rgb.xml"])
 def test_ome_rgb(data_path, xml_file):
     """


### PR DESCRIPTION
The OME::Image attribute "Name" is optional in the specification. Corrected code to support when attribute is not there.